### PR TITLE
verifyのスキップ方式の変更

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -5,19 +5,28 @@ on:
     branches:
       - main
       - develop
-    paths:
-      - '**.hpp'
-      - '**.cpp'
   pull_request:
     branches:
       - main
       - develop
-    paths:
-      - '**.hpp'
-      - '**.cpp'
 
 jobs:
+  pre_job:
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@master
+        with:
+          skip_after_successful_duplicate: 'true'
+          paths: '["**.hpp", "**.cpp"]'
+
   oj-verify:
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## 概要

テスト用のワークフローそのものの実行をスキップせず、起動後にスキップするようにする。

## 目的

保護ブランチのテストが実行されない問題を解決する。(Issue #11 )

## 実装内容

[Skip Duplicate Actions](https://github.com/marketplace/actions/skip-duplicate-actions)を`verify.yml`に追加