### PR TITLE
生成したPDFをreleaseブランチにPushする機能を追加

### DIFF
--- a/.github/workflows/make_pdf.yml
+++ b/.github/workflows/make_pdf.yml
@@ -34,9 +34,10 @@ jobs:
           name: library-PDF
           path: output/main.pdf
 
-      #  以下は保護されたブランチに対しては失敗する
-      # - name: Commit changes
-      #   uses: EndBug/add-and-commit@v7
-      #   with:
-      #     add: output
-      #     default_author: github_actions
+      - name: Deploy PDF to release branch
+        uses: EndBug/add-and-commit@v7
+        with:
+          message: 'Deploy PDF by GitHub Actions ($GITHUB_WORKFLOW)'
+          add: output
+          branch: release
+          default_author: github_actions

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # YNU ICPC Library
 
-[![verify](https://github.com/YNUCPC/ynu-icpc-library/actions/workflows/verify.yml/badge.svg)](https://github.com/YNUCPC/ynu-icpc-library/actions/workflows/verify.yml)
+[![verify](https://github.com/YNUCPC/ynu-icpc-library/actions/workflows/verify.yml/badge.svg)](https://github.com/YNUCPC/ynu-icpc-library/actions/workflows/verify.yml) [![make PDF](https://github.com/YNUCPC/ynu-icpc-library/actions/workflows/make_pdf.yml/badge.svg)](https://github.com/YNUCPC/ynu-icpc-library/actions/workflows/make_pdf.yml)
 
 横浜国立大学競技プログラミング部のICPC用のライブラリです。
+
+ライブラリの内容は以下のリンクから参照できます。
+
+- [YNU ICPC Library(PDF)](https://github.com/YNUCPC/ynu-icpc-library/blob/release/output/main.pdf)
 
 ## 方針
 


### PR DESCRIPTION
## 概要

Issue #16 に対する修正

ワークフローで生成したPDFが `main` ブランチに直接自動Pushできないため、`release` ブランチに自動Pushするように変更

## 目的

[ワークフロー生成物の保存](https://docs.github.com/ja/actions/advanced-guides/storing-workflow-data-as-artifacts)では保存期間が90日までと期限があるため、半永久的に保存するためにリポジトリに置く

## 変更内容

- [Add & Commit](https://github.com/marketplace/actions/add-commit)でPush先のブランチを設定
- `README.md` にPDFへのリンクを追加