### PR TITLE
PDFをGitHub Pagesへアップロードする

### DIFF
--- a/.github/workflows/make_pdf.yml
+++ b/.github/workflows/make_pdf.yml
@@ -34,10 +34,9 @@ jobs:
           name: library-PDF
           path: output/main.pdf
 
-      - name: Deploy PDF to release branch
-        uses: EndBug/add-and-commit@v7
+      - name: Deploy PDF to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.ref == 'refs/heads/main' }}
         with:
-          message: 'Deploy PDF by GitHub Actions (${{ github.workflow }})'
-          add: output
-          branch: release
-          default_author: github_actions
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./output


### PR DESCRIPTION
## 概要

Issue #26 に対する修正
[GitHub Pages Action](https://github.com/marketplace/actions/github-pages-action)を利用してPDFを `gh-page` ブランチにアップロードし、Github Pagesで公開する。

## TODO

最初のマージ後は公式ドキュメントの [First Deployment with `GITHUB_TOKEN`](https://github.com/marketplace/actions/github-pages-action#%EF%B8%8F-first-deployment-with-github_token) に従ってGithub Pagesの設定を行う。