### PR TITLE
テストケースをキャッシュに保存する

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -36,6 +36,14 @@ jobs:
       - name: Install dependencies
         run: pip3 install online-judge-verify-helper
 
+      - name: Cache test cases
+        uses: actions/cache@v2
+        with:
+          path: /.verify-helper/cache
+          key: ${{ runner.os }}-verify-helper-${{ hashFiles('**/test.cpp') }}
+          restore-keys: |
+            ${{ runner.os }}-verify-helper-
+
       - name: Run tests
         run: oj-verify run --jobs 2
 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /.verify-helper/cache
-          key: ${{ runner.os }}-verify-helper-${{ hashFiles('**/test.cpp') }}
+          key: ${{ runner.os }}-verify-helper-${{ hashFiles('**.test.cpp') }}
           restore-keys: |
             ${{ runner.os }}-verify-helper-
 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -39,8 +39,8 @@ jobs:
       - name: Cache test cases
         uses: actions/cache@v2
         with:
-          path: /.verify-helper/cache
-          key: ${{ runner.os }}-verify-helper-${{ hashFiles('**.test.cpp') }}
+          path: ./.verify-helper/cache
+          key: ${{ runner.os }}-verify-helper-${{ hashFiles('**/*.test.cpp') }}
           restore-keys: |
             ${{ runner.os }}-verify-helper-
 

--- a/test/aoj/0341.test.cpp
+++ b/test/aoj/0341.test.cpp
@@ -3,7 +3,8 @@
 #include "src/math/modint.hpp"
 using namespace std;
 
-using mint = Modint<1000000007>;
+constexpr long long MOD = 1000000007;
+using mint = Modint<MOD>;
 
 int main() {
     int n, m;

--- a/test/aoj/0341.test.cpp
+++ b/test/aoj/0341.test.cpp
@@ -12,8 +12,7 @@ int main() {
     cin >> t >> b;
     n = t.size();
     m = b.size();
-    vector<vector<mint> > dp(n + 1);  // dp[i][j]=tのi文字目までみてbのj文字目までつくる通り
-    for (int i = 0; i <= n; i++) dp[i].resize(m + 1, 0);
+    vector<vector<mint> > dp(n + 1, vector<mint>(m + 1, 0));  // dp[i][j]=tのi文字目までみてbのj文字目までつくる通り
     dp[0][0] = 1;
     for (int i = 0; i < n; i++) {
         for (int j = 0; j <= m; j++) {

--- a/test/aoj/DSL_2_A.test.cpp
+++ b/test/aoj/DSL_2_A.test.cpp
@@ -9,6 +9,8 @@ int op(int a, int b) { return min(a, b); }
 constexpr int e() { return INF; }
 
 int main() {
+    cin.tie(nullptr);
+    ios::sync_with_stdio(false);
     int n, q;
     cin >> n >> q;
     SegmentTree<int, op, e> seg(n);

--- a/test/aoj/NTL_1_B.test.cpp
+++ b/test/aoj/NTL_1_B.test.cpp
@@ -3,7 +3,8 @@
 #include "src/math/modint.hpp"
 using namespace std;
 
-using mint = Modint<1000000007>;
+constexpr long long MOD = 1000000007;
+using mint = Modint<MOD>;
 
 int main() {
     int m, n;


### PR DESCRIPTION
- #31 
- [actions/cache](https://github.com/marketplace/actions/cache) を使用してverify用のテストケースをキャッシュに保存する

## メモ

- `**.test.cpp` にマッチするすべてのファイルを使用して得られるハッシュ値をキャッシュの key としているので、少しでもテストの内容を変更すると新たなキャッシュが生成される
- テストケースは大した容量ではないので問題はなさそう