### PR TITLE
高速ゼータ変換の追加

### DIFF
--- a/docs/math.tex
+++ b/docs/math.tex
@@ -2,3 +2,4 @@
 
 \input{docs/math/modint.tex}
 \input{docs/math/FFT.tex}
+\input{docs/math/subset_zeta.tex}

--- a/docs/math/subset_zeta.tex
+++ b/docs/math/subset_zeta.tex
@@ -1,0 +1,14 @@
+\subsection{高速ゼータ変換・メビウス変換}
+
+部分集合に対するゼータ変換・メビウス変換を集合の要素数を$n$として$O(n2^n)$で行うアルゴリズム。
+
+bitwise AND畳み込みやbitwise OR畳み込みを高速化できる。
+
+\begin{itemize}
+    \item subset\_zeta(f, n, inv) : 長さ$2^n$の配列$f$の下位集合ゼータ変換$F[S] = \sum_{X \subseteq S} f(X)$を求める。
+    \item supset\_zeta(f, n, inv) : 長さ$2^n$の配列$f$の上位集合ゼータ変換$F[S] = \sum_{X \supseteq S} f(X)$を求める。
+\end{itemize}
+
+inv=true のとき逆変換としてメビウス変換を行い、$F$から$f$を求める。
+
+\lstinputlisting[firstline=5]{src/math/subset_zeta.hpp}

--- a/src/math/subset_zeta.hpp
+++ b/src/math/subset_zeta.hpp
@@ -1,0 +1,35 @@
+#pragma once
+#include <bits/stdc++.h>
+using namespace std;
+
+template <class T>
+vector<T> subset_zeta(vector<T> f, int n, bool inv = false) {
+    for (int i = 0; i < n; i++) {
+        for (int S = 0; S < (1 << n); S++) {
+            if ((S & (1 << i)) != 0) {  // if i in S
+                if (!inv) {
+                    f[S] += f[S ^ (1 << i)];
+                } else {
+                    f[S] -= f[S ^ (1 << i)];
+                }
+            }
+        }
+    }
+    return f;
+}
+
+template <class T>
+vector<T> supset_zeta(vector<T> f, int n, bool inv = false) {
+    for (int i = 0; i < n; i++) {
+        for (int S = 0; S < (1 << n); S++) {
+            if ((S & (1 << i)) == 0) {  // if i not in S
+                if (!inv) {
+                    f[S] += f[S ^ (1 << i)];
+                } else {
+                    f[S] -= f[S ^ (1 << i)];
+                }
+            }
+        }
+    }
+    return f;
+}

--- a/test/library_checker/bitwise_and_convolution.test.cpp
+++ b/test/library_checker/bitwise_and_convolution.test.cpp
@@ -1,0 +1,41 @@
+#define PROBLEM "https://judge.yosupo.jp/problem/bitwise_and_convolution"
+#include <bits/stdc++.h>
+#include "../../src/math/subset_zeta.hpp"
+#include "../../src/math/modint.hpp"
+using namespace std;
+
+using ll = long long;
+constexpr ll MOD = 998244353;
+using mint = Modint<MOD>;
+
+int main() {
+    cin.tie(nullptr);
+    ios::sync_with_stdio(false);
+    int n;
+    cin >> n;
+    vector<mint> a(1 << n), b(1 << n);
+    for (int i = 0; i < 1 << n; i++) {
+        ll x;
+        cin >> x;
+        a[i] = x;
+    }
+    for (int i = 0; i < 1 << n; i++) {
+        ll x;
+        cin >> x;
+        b[i] = x;
+    }
+    // ゼータ変換
+    vector<mint> A = supset_zeta(a, n, false), B = supset_zeta(b, n, false);
+    // AND畳み込み
+    vector<mint> C(1 << n);
+    for (int S = 0; S < 1 << n; S++) {
+        C[S] = A[S] * B[S];
+    }
+    // メビウス変換
+    vector<mint> c = supset_zeta(C, n, true);
+
+    for (int i = 0; i < 1 << n; i++) {
+        cout << c[i].val() << " \n"[i == (1 << n) - 1];
+    }
+    return 0;
+}


### PR DESCRIPTION
部分集合に対する高速ゼータ変換・メビウス変換の追加。

## 計算量

要素数 n の集合に対し、O(n 2^n)

## メモ

テストは上位集合に対するゼータ変換・メビウス変換のみですが、下位集合も実装はほぼ同じなので問題はないと思います
