### PR TITLE
modintをiostreamに対応させる

### DIFF
--- a/docs/math/modint.tex
+++ b/docs/math/modint.tex
@@ -5,20 +5,3 @@
 using mint = modint\verb|<|1000000007\verb|>|; 等のように定義して使用するのが推奨。
 
 \lstinputlisting[firstline=5]{src/math/modint.hpp}
-
-\subsubsection*{入出力ストリームの実装}
-
-\begin{lstlisting}
-using mint = Modint<MOD>;
-
-// 入出力ストリーム
-istream& operator>>(istream& is, mint& x) {
-    long long a;
-    is >> a;
-    x = a;
-    return is;
-}
-ostream& operator<<(ostream& os, mint& x) {
-    return os << x.val();
-}
-\end{lstlisting}

--- a/src/math/modint.hpp
+++ b/src/math/modint.hpp
@@ -49,7 +49,7 @@ struct Modint {
     // 入出力ストリーム
     friend ostream& operator<<(ostream& os, const mint& p) { return os << p.v; }
     friend istream& operator>>(istream& is, mint& p) {
-        int64_t t;
+    long long t;
         is >> t;
         p = mint(t);
         return (is);

--- a/src/math/modint.hpp
+++ b/src/math/modint.hpp
@@ -49,7 +49,7 @@ struct Modint {
     // 入出力ストリーム
     friend ostream& operator<<(ostream& os, const mint& p) { return os << p.v; }
     friend istream& operator>>(istream& is, mint& p) {
-    long long t;
+        long long t;
         is >> t;
         p = mint(t);
         return (is);

--- a/src/math/modint.hpp
+++ b/src/math/modint.hpp
@@ -46,4 +46,12 @@ struct Modint {
     mint operator*(const mint rhs) const { return mint(*this) *= rhs; }
     mint operator/(const mint rhs) const { return mint(*this) /= rhs; }
     mint operator-() const { return mint() - *this; }  // 単項
+    // 入出力ストリーム
+    friend ostream& operator<<(ostream& os, const mint& p) { return os << p.v; }
+    friend istream& operator>>(istream& is, mint& p) {
+        int64_t t;
+        is >> t;
+        p = mint(t);
+        return (is);
+    }
 };

--- a/test/aoj/0341.test.cpp
+++ b/test/aoj/0341.test.cpp
@@ -22,6 +22,6 @@ int main() {
             }
         }
     }
-    cout << dp[n][m].val() << endl;
+    cout << dp[n][m] << endl;
     return 0;
 }

--- a/test/aoj/2863.test.cpp
+++ b/test/aoj/2863.test.cpp
@@ -53,5 +53,5 @@ int main() {
             }
         }
     }
-    cout << dp[m].val() << endl;
+    cout << dp[m] << endl;
 }

--- a/test/aoj/NTL_1_B.test.cpp
+++ b/test/aoj/NTL_1_B.test.cpp
@@ -7,9 +7,9 @@ constexpr long long MOD = 1000000007;
 using mint = Modint<MOD>;
 
 int main() {
-    int m, n;
+    mint m;
+    int n;
     cin >> m >> n;
-    mint ans = mint(m).pow(n);
-    cout << ans.val() << endl;
+    cout << m.pow(n) << endl;
     return 0;
 }

--- a/test/library_checker/bitwise_and_convolution.test.cpp
+++ b/test/library_checker/bitwise_and_convolution.test.cpp
@@ -15,14 +15,10 @@ int main() {
     cin >> n;
     vector<mint> a(1 << n), b(1 << n);
     for (int i = 0; i < 1 << n; i++) {
-        ll x;
-        cin >> x;
-        a[i] = x;
+        cin >> a[i];
     }
     for (int i = 0; i < 1 << n; i++) {
-        ll x;
-        cin >> x;
-        b[i] = x;
+        cin >> b[i];
     }
     // ゼータ変換
     vector<mint> A = supset_zeta(a, n, false), B = supset_zeta(b, n, false);
@@ -35,7 +31,7 @@ int main() {
     vector<mint> c = supset_zeta(C, n, true);
 
     for (int i = 0; i < 1 << n; i++) {
-        cout << c[i].val() << " \n"[i == (1 << n) - 1];
+        cout << c[i] << " \n"[i == (1 << n) - 1];
     }
     return 0;
 }


### PR DESCRIPTION
- #42 の実装

## 変更点

- `Modint` にiostream演算子のオーバーロードを追加
- ライブラリからmodintの入出力に関する補足の記述を削除。（ライブラリとして実装したため）
- testのコードでiostreamを使用するように変更
