### PR TITLE
LaTeXの書式設定の調整

### DIFF
--- a/main_1col.tex
+++ b/main_1col.tex
@@ -1,4 +1,4 @@
-\documentclass[12pt,a4paper,dvipdfmx]{jsarticle}
+\documentclass[9pt,a4paper,dvipdfmx]{jsarticle}
 
 \input{preamble.tex}
 

--- a/main_2col.tex
+++ b/main_2col.tex
@@ -1,4 +1,4 @@
-\documentclass[12pt,a4paper,landscape,twocolumn,dvipdfmx]{jsarticle}  % 用紙横向き、二段組
+\documentclass[9pt,a4paper,landscape,twocolumn,dvipdfmx]{jsarticle}  % 用紙横向き、二段組
 
 \input{preamble.tex}
 

--- a/preamble.tex
+++ b/preamble.tex
@@ -1,4 +1,4 @@
-\usepackage[margin=15mm]{geometry}  % 余白調整
+\usepackage[a4paper,left=7mm,right=7mm,bottom=7mm,top=12mm,headsep=0.5mm]{geometry}  % 余白調整
 \usepackage{fancyhdr}  % ヘッダー・フッターの書式
 \usepackage{listings,jlisting}  % コードブロック
 \usepackage{color}  % 文字に色をつける

--- a/preamble.tex
+++ b/preamble.tex
@@ -16,7 +16,7 @@
 \lstset{
   language={C++},
   backgroundcolor={\color[RGB]{250,250,250}}, % 背景色
-  basicstyle={\ttfamily\small}, % 標準の書式. フォントサイズなど
+  basicstyle={\ttfamily\footnotesize}, % 標準の書式. フォントサイズなど
   identifierstyle={}, % キーワード以外の書式
   commentstyle={\itshape \color[RGB]{0,128,0}},% コメントの書式
   keywordstyle={\bfseries \color{blue}},% キーワードの書式
@@ -29,11 +29,11 @@
   columns=fixed,%
   basewidth=0.5em,
   xrightmargin=0zw, %
-  xleftmargin=3zw,%
+  xleftmargin=1zw,%
   numbers=left, % 行番号表示位置
   numberstyle={\scriptsize}, % 行番号の書式
   stepnumber=1, % 行番号の表示行数間隔
   numbersep=1zw, % 行番号と本文の間隔
-  lineskip=-0.5ex, % 行間隔
+  lineskip=-0.6ex, % 行間隔
   tabsize=4,
 }


### PR DESCRIPTION
## Issue

- #59 

## 変更点

- 標準の文字サイズを12ptから9ptに変更
- ページ余白を狭く変更
- コードブロック内の行間の幅を縮小
- コードブロックの横幅を広く変更
