### PR TITLE
ライブラリPDFの自動コミットを行うActionの追加

### DIFF
--- a/.github/workflows/make_pdf.yml
+++ b/.github/workflows/make_pdf.yml
@@ -29,19 +29,29 @@ jobs:
           docker run --rm -v $PWD:/workdir paperist/texlive-ja:latest latexmk main_1col.tex
           docker run --rm -v $PWD:/workdir paperist/texlive-ja:latest latexmk main_2col.tex
 
-      - name: Move to output
-        run: |
-          mkdir -p output
-          mv main_*.pdf output
-
-      - uses: actions/upload-artifact@v2
+      - name: Upload PDF
+        uses: actions/upload-artifact@v2
         with:
           name: library-PDF
-          path: output/main_*.pdf
+          path: main_*.pdf
 
-      - name: Deploy PDF to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.ref == 'refs/heads/main' }}
+  pdf-auto-commit:
+    if: ${{ github.ref == 'refs/heads/main' }}
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@v2
+
+      - name: Download PDF
+        uses: actions/download-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./output
+          name: library-PDF
+
+      - name: Commit PDF
+        uses: EndBug/add-and-commit@v9
+        with:
+          message: 'Update Library PDF'
+          default_author: github_actions
+          add: '*.pdf'


### PR DESCRIPTION
# Issue

- #72 

# 変更点

- job `pdf-auto-commit` の追加。
  - artifactにアップロードされたPDFをダウンロードしてcommitする。mainブランチのみで実行する（そうしないとめっちゃコンフリクトしそう？）
- GitHub Pages へのアップロードを廃止
