### PR TITLE
actions/checkoutをv1に変更

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v1  # use checkout@v1 for oj-verify's timestamp
 
       - name: Set up Python
         uses: actions/setup-python@v2
@@ -47,7 +47,7 @@ jobs:
       - name: Run tests
         env:
           DROPBOX_TOKEN: ${{ secrets.ATCODER_DROPBOX_TOKEN }}
-        run: oj-verify run --jobs 2 --timeout 1800
+        run: oj-verify run --jobs 2
 
       - name: Upload timestamp
         uses: actions/upload-artifact@v2

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -90,7 +90,7 @@ jobs:
 
     steps:
       - name: Set up Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v
 
       - name: Set up Python
         uses: actions/setup-python@v2


### PR DESCRIPTION
# 修正理由

- `oj-verify run` で生成される `./verify-helper/timestamps.remote.json` が checkout@v2 以降で正しく動作しない